### PR TITLE
All options overwritable per wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ at such places that the closing and opening div tags interfere with the reveal.j
 MathJax compatibility
 ----------------------
 
-At the moment this plugin loads MathJax from the MathJax CDN directly whether the Dokuwiki MathJax plugin is installed or not. It ignores Dokuwiki's MathJax plugin and the custom settings you might have made. 
+At the moment this plugin loads MathJax from the MathJax CDN directly whether the Dokuwiki MathJax plugin is installed or not. It ignores Dokuwiki's MathJax plugin and the custom settings you might have made.
 
 
 
@@ -69,7 +69,7 @@ Configuration is done in DokuWiki's configuration manager.
 ### Available themes
 
 
-Available themes are the Reval.js themes. Possible values:
+Available themes are the Reveal.js themes. Possible values:
 
   * black
   * white
@@ -167,6 +167,11 @@ Alternatively, to select a theme put a
 ```
 somehere with ``theme_name`` replaced by one of the reveal.js themes as listed under "Available themes".
 
+All other options are also overwritable in a wiki page by using the URL query parameter syntax:
+```
+~~REVEAL theme=sky&transition=convex&controls=1&show_progress_bar=1&build_all_lists=0&open_in_new_window=1~~
+```
+Please note that boolean values must be numeric (1 or 0). If you want to be able to change the options directly in the URL after the presentation has started, then you have to disable DokuWiki's caching by putting `~~NOCACHE~~` at the top of the page.
 
 ### Slide background
 
@@ -176,7 +181,7 @@ The plugin introduces the syntax
    {{background>value}}
 ```
 
-Where `value` can be either a Dokuwiki image identifier, e.g. 
+Where `value` can be either a Dokuwiki image identifier, e.g.
 
 ```
   value = :images:my_images:image1.png
@@ -245,6 +250,3 @@ http://example-dokuwiki.com/doku.php?do=export_revealjs&id=example:page&print-pd
 ```
 After that the presentation looks weird in the browser but can be printed via you browser's print function.
 Officially only Chromium and Chrome are supported for PDF export. Check also the  [Reveal.js PDF export documentation](https://github.com/hakimel/reveal.js#pdf-export).
-
-
-

--- a/example_presentation.dokuwiki
+++ b/example_presentation.dokuwiki
@@ -1,10 +1,29 @@
-~~REVEAL~~
-====== revealjs test ======
+~~NOCACHE~~
+~~REVEAL theme=sky&transition=convex&controls=1&show_progress_bar=1&build_all_lists=1&open_in_new_window=1~~
+
+
+====== Revealjs Test ======
 
 This is a test suite for the reval.js plugin.
 
+
+===== Caching =====
+
+If you disable the cache for the page, then you are able to change the options direct in the URL.
+
+In case your theme does not match the environment for the presentation you can fix this very fast.
+
+===== List =====
+
+  * Unordered list, item one
+  * Another item
+    - Ordered sublist
+    - Another sublist item
+  * A third item for testing
+
+
 {{background>#000000}}
-===== background =====
+===== Background =====
 
 This slide has black background.
 
@@ -19,12 +38,13 @@ Display math
 \]
 
 
-===== code  =====
+===== Code  =====
 
 Inline ''this is code''
 
+
 ==== Python ====
-Downloadable snippet
+Downloadable Snippet
 
 <code python test.py>
 from antigravity import *
@@ -32,7 +52,8 @@ for k in range(10):
     print(k)
 </code>
 
-=== not downloadable snippet ===
+
+=== Not Downloadable Snippet ===
 
 <code python>
 from antigravity import *
@@ -40,7 +61,8 @@ for k in range(10):
     print(k)
 </code>
 
-==== bash ====
+
+==== Bash ====
 
 <code python test.py>
 #!/bin/bash
@@ -49,53 +71,57 @@ echo "hello world"
 </code>
 
 
-==== no language ====
+==== No Language ====
 <code - test.nolanguage>
 for k in range(10)
 this is nothing
 reject this
 </code>
 
-==== double space block code ====
+
+==== Double Space Block Code ====
 
   first line
   second line
   third line
-  
-  
-===== tables =====
 
-==== a simple table ====
+
+===== Tables =====
+
+
+==== A Simple Table ====
 
 ^ head 1 ^ head 2 ^
 | line1 | line 2 |
 | line11 | line 22 |
 
 
-===== media alignment =====
+===== Media Alignment =====
 
-==== align left ====
+
+==== Align Left ====
 
 {{wiki:dokuwiki-128.png }}
-asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj  asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj 
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labor
 
-==== align right ====
+
+==== Align Right ====
 
 {{ wiki:dokuwiki-128.png}}
-asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj  asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj 
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labor
 
 
-==== align center ====
+==== Align Center ====
 
 {{ wiki:dokuwiki-128.png }}
 
-asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj  asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj asdflkj as;dflk jasd;lfk ja;lkfkj asl;dkfj asldkfj 
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labor
 
 
+===== Fonts =====
 
-===== fonts =====
 
-==== small fonts ====
+==== Small Fonts ====
 
 Normal size and <wrap lo>small size</wrap>
 
@@ -105,7 +131,8 @@ normal normal normal
 small block small block small block
 </WRAP>
 
-===== links =====
+
+===== Links =====
 
 Interwiki link [[wiki:maintenance:djvu_support]]
 
@@ -113,11 +140,11 @@ WWW link www.google.de
 
 
 {{background>wiki:dokuwiki-128.png}}
-====== h1 with backgounrd ======
+====== H1 With Background ======
 with background
 
-===== without backgounrd 1=====
 
-===== without backgounrd 2=====
+===== Without Background 1 =====
 
 
+===== Without Background 2 =====

--- a/example_presentation.dokuwiki
+++ b/example_presentation.dokuwiki
@@ -11,7 +11,7 @@ This is a test suite for the reval.js plugin.
 
 If you disable the cache for the page, then you are able to change the options direct in the URL.
 
-In case your theme does not match the environment for the presentation you can fix this very fast.
+In case your theme does not match the environment for the presentation you can fix this very fast without editing the page.
 
 ===== List =====
 

--- a/renderer.php
+++ b/renderer.php
@@ -161,13 +161,13 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
                     { src: \''.$this->base.'plugin/zoom-js/zoom.js\', async: true, condition: function() { return !!document.body.classList; } },
                     { src: \''.$this->base.'plugin/notes/notes.js\', async: true, condition: function() { return !!document.body.classList; } },
 
-                                        // MathJax
-                                       { src: \''.$this->base.'plugin/math/math.js\', async: true }
+                    // MathJax
+                    { src: \''.$this->base.'plugin/math/math.js\', async: true }
                 ]
             });
 
         </script>
-         </body>
+</body>
 </html>';
     }
 

--- a/renderer.php
+++ b/renderer.php
@@ -50,6 +50,19 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
         global $conf;
         global $lang;
 
+        // merge URL params into plugin conf - changing params direct in the URL is only working, when page is not cached (~~NOCACHE~~)
+        if (count($_GET)){
+            if (!array_key_exists('plugin', $conf)) {
+                $conf['plugin'] = array('revealjs' => $_GET);
+            }
+            elseif (!array_key_exists('revealjs', $conf[plugin])) {
+                $conf[plugin]['revealjs'] = $_GET;
+            }
+            else {
+                $conf[plugin][revealjs] = array_merge($conf[plugin][revealjs], $_GET);
+            }
+        }
+
         // call the parent
         parent::document_start();
 
@@ -57,10 +70,10 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
         $headers = array(
             'Content-Type' => 'text/html; charset=utf-8'
         );
-       $theme = isset($_GET['theme'])?$_GET['theme']:$this->getConf('theme');
-       p_set_metadata($ID,array('format' => array('revealjs' => $headers) ));
+
+        p_set_metadata($ID,array('format' => array('revealjs' => $headers) ));
         $this->base = DOKU_BASE.'lib/plugins/revealjs/';
-       $this->doc = '
+        $this->doc = '
 <!DOCTYPE html>
 <html lang="'.$conf['lang'].'" dir="'.$lang['direction'].'">
 
@@ -75,7 +88,7 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
 
         <link rel="stylesheet" href="'.$this->base.'css/reveal.css">
-        <link rel="stylesheet" href="'.$this->base.'css/theme/'.$theme.'.css" id="theme">
+        <link rel="stylesheet" href="'.$this->base.'css/theme/'.$this->getConf('theme').'.css" id="theme">
         <link rel="stylesheet" href="'.$this->base.'doku-substitutes.css">
 
         <!-- Code syntax highlighting -->
@@ -366,6 +379,7 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
     * This is called "fragment" in reveal.js
     */
     function listitem_open($level, $node=false) {
+        dbg($conf);
         if($this->getConf('build_all_lists')) {
           $this->doc .= '<li class="fragment">';
        } else {

--- a/renderer.php
+++ b/renderer.php
@@ -64,47 +64,46 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
 <!DOCTYPE html>
 <html lang="'.$conf['lang'].'" dir="'.$lang['direction'].'">
 
-	<head>
-		<meta charset="utf-8">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
-		<title>'.tpl_pagetitle($ID, true).'</title>
+        <title>'.tpl_pagetitle($ID, true).'</title>
 
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
 
-		<meta name="apple-mobile-web-app-capable" content="yes" />
-		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <link rel="stylesheet" href="'.$this->base.'css/reveal.css">
+        <link rel="stylesheet" href="'.$this->base.'css/theme/'.$theme.'.css" id="theme">
+        <link rel="stylesheet" href="'.$this->base.'doku-substitutes.css">
 
-		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
+        <!-- Code syntax highlighting -->
+        <link rel="stylesheet" href="'.$this->base.'lib/css/zenburn.css">
 
-                <link rel="stylesheet" href="'.$this->base.'css/reveal.css">
-		<link rel="stylesheet" href="'.$this->base.'css/theme/'.$theme.'.css" id="theme">
-                <link rel="stylesheet" href="'.$this->base.'doku-substitutes.css"> 
+        <!-- Printing and PDF exports -->
+        <script>
+            var link = document.createElement( \'link\' );
+            link.rel = \'stylesheet\';
+            link.type = \'text/css\';
+            link.href = window.location.search.match( /print-pdf/gi ) ? \''.$this->base.'css/print/pdf.css\' : \''.$this->base.'css/print/paper.css\';
+            document.getElementsByTagName( \'head\' )[0].appendChild( link );
+        </script>
 
-		<!-- Code syntax highlighting -->
-		<link rel="stylesheet" href="'.$this->base.'lib/css/zenburn.css">
-
-		<!-- Printing and PDF exports -->
-		<script>
-			var link = document.createElement( \'link\' );
-			link.rel = \'stylesheet\';
-			link.type = \'text/css\';
-			link.href = window.location.search.match( /print-pdf/gi ) ? \''.$this->base.'css/print/pdf.css\' : \''.$this->base.'css/print/paper.css\';
-			document.getElementsByTagName( \'head\' )[0].appendChild( link );
-		</script>
-
-		<!--[if lt IE 9]>
-		<script src='.$this->base.'"lib/js/html5shiv.js"></script>
-		<![endif]-->
-	</head>
+        <!--[if lt IE 9]>
+        <script src='.$this->base.'"lib/js/html5shiv.js"></script>
+        <![endif]-->
+    </head>
 <body>
 
-		<div class="reveal">
+    <div class="reveal">
 
-			<!-- Any section element inside of this container is displayed as a slide -->
-			<div class="slides">
+        <!-- Any section element inside of this container is displayed as a slide -->
+        <div class="slides">
 ';
     }
 
- 
+
 
     /**
      * Closes the document
@@ -124,37 +123,37 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
         $show_controls = $this->getConf('controls') ? 'true' : 'false';
         $show_progress_bar = $this->getConf('show_progress_bar') ? 'true' : 'false';
         $this->doc .= '</div></div>
-		<script src="'.$this->base.'lib/js/head.min.js"></script>
-		<script src="'.$this->base.'js/reveal.js"></script>
+        <script src="'.$this->base.'lib/js/head.min.js"></script>
+        <script src="'.$this->base.'js/reveal.js"></script>
 
-		<script>
+        <script>
 
-			Reveal.initialize({
-				controls: '. $show_controls .',
-				progress: '. $show_progress_bar .',
-				history: true,
-				center: true,
+            Reveal.initialize({
+                controls: '. $show_controls .',
+                progress: '. $show_progress_bar .',
+                history: true,
+                center: true,
 
-				transition: \''.$this->getConf('transition').'\', // none/fade/slide/convex/concave/zoom
-				math: {
+                transition: \''.$this->getConf('transition').'\', // none/fade/slide/convex/concave/zoom
+                math: {
                                    mathjax: \'//cdn.mathjax.org/mathjax/latest/MathJax.js\',
                                    config: \'TeX-AMS_HTML-full\'  // See http://docs.mathjax.org/en/latest/config-files.html
                                 },
 
-				dependencies: [
-					{ src: \''.$this->base.'lib/js/classList.js\', condition: function() { return !document.body.classList; } },
-					{ src: \''.$this->base.'plugin/markdown/marked.js\', condition: function() { return !!document.querySelector( \'[data-markdown]\' ); } },
-					{ src: \''.$this->base.'plugin/markdown/markdown.js\', condition: function() { return !!document.querySelector( \'[data-markdown]\' ); } },
-					{ src: \''.$this->base.'plugin/highlight/highlight.js\', async: true, condition: function() { return !!document.querySelector( \'pre code\' ); }, callback: function() { hljs.initHighlightingOnLoad(); } },
-					{ src: \''.$this->base.'plugin/zoom-js/zoom.js\', async: true, condition: function() { return !!document.body.classList; } },
-					{ src: \''.$this->base.'plugin/notes/notes.js\', async: true, condition: function() { return !!document.body.classList; } },
+                dependencies: [
+                    { src: \''.$this->base.'lib/js/classList.js\', condition: function() { return !document.body.classList; } },
+                    { src: \''.$this->base.'plugin/markdown/marked.js\', condition: function() { return !!document.querySelector( \'[data-markdown]\' ); } },
+                    { src: \''.$this->base.'plugin/markdown/markdown.js\', condition: function() { return !!document.querySelector( \'[data-markdown]\' ); } },
+                    { src: \''.$this->base.'plugin/highlight/highlight.js\', async: true, condition: function() { return !!document.querySelector( \'pre code\' ); }, callback: function() { hljs.initHighlightingOnLoad(); } },
+                    { src: \''.$this->base.'plugin/zoom-js/zoom.js\', async: true, condition: function() { return !!document.body.classList; } },
+                    { src: \''.$this->base.'plugin/notes/notes.js\', async: true, condition: function() { return !!document.body.classList; } },
 
                                         // MathJax
                                        { src: \''.$this->base.'plugin/math/math.js\', async: true }
-				]
-			});
+                ]
+            });
 
-		</script>
+        </script>
          </body>
 </html>';
     }
@@ -169,7 +168,7 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
             if ($this->next_slide_with_background){
                $this->doc .= ' data-background="'.$this->background_image_url.'"';
                $this->next_slide_with_background = false;
-            } 
+            }
              if ($this->next_slide_without_footer) {
                 $this->doc .= ' data-state="no-footer"';
                 $this->next_slide_without_footer = false;
@@ -220,7 +219,7 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
     }
 
    function section_close() {
-    
+
    }
 
     /**
@@ -247,7 +246,7 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
      * @param int $numrows NOT IMPLEMENTED
      * @param int $pos     byte position in the original source
      */
-    function table_open($maxcols = null, $numrows = null, $pos = null) {
+    function table_open($maxcols = null, $numrows = null, $pos = null, $classes = NULL) {
         // initialize the row counter used for classes
         $this->_counter['row_counter'] = 0;
         $class                         = 'table';
@@ -264,7 +263,7 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
      * @param int $pos byte position in the original source
      */
     function table_close($pos = null) {
-        $this->doc .= '</table>'.DOKU_LF; 
+        $this->doc .= '</table>'.DOKU_LF;
     }
 
     /**
@@ -284,7 +283,7 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
     /**
      * Open a table row
      */
-    function tablerow_open() {
+    function tablerow_open($classes = NULL) {
         $this->doc .= DOKU_TAB.'<tr>'.DOKU_LF.DOKU_TAB.DOKU_TAB;
     }
 
@@ -302,7 +301,7 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
      * @param string $align left|center|right
      * @param int    $rowspan
      */
-    function tableheader_open($colspan = 1, $align = null, $rowspan = 1) {
+    function tableheader_open($colspan = 1, $align = null, $rowspan = 1, $classes = NULL) {
         $class = 'class="col'.$this->_counter['cell_counter']++;
         if(!is_null($align)) {
             $class .= ' '.$align.'align';
@@ -333,7 +332,7 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
      * @param string $align left|center|right
      * @param int    $rowspan
      */
-    function tablecell_open($colspan = 1, $align = null, $rowspan = 1) {
+    function tablecell_open($colspan = 1, $align = null, $rowspan = 1, $classes = NULL) {
         $class = 'class="col'.$this->_counter['cell_counter']++;
         if(!is_null($align)) {
             $class .= ' '.$align.'align';
@@ -370,11 +369,11 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
         if($this->getConf('build_all_lists')) {
           $this->doc .= '<li class="fragment">';
        } else {
-          $this->doc .= '<li>'; 
+          $this->doc .= '<li>';
        }
     }
 
-  
+
     /**
      * Don't use Geshi. Overwrite ths Geshi function.
      * @author Emmanuel Klinger
@@ -423,5 +422,3 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
     }
 
 }
-
-

--- a/syntax/theme.php
+++ b/syntax/theme.php
@@ -73,7 +73,7 @@ class syntax_plugin_revealjs_theme extends DokuWiki_Syntax_Plugin {
      * @see handle()
      */
     public function render($mode, Doku_Renderer $renderer, $data) {
-        global $ID, $conf;
+        global $ID;
 
         if($mode == 'xhtml'){
             if (is_a($renderer, 'renderer_plugin_revealjs')){
@@ -82,13 +82,13 @@ class syntax_plugin_revealjs_theme extends DokuWiki_Syntax_Plugin {
             else {
                 // create button to start the presentation
                 if (array_key_exists('open_in_new_window', $data)){
-                    $target = $data[open_in_new_window] ? '"_blank"' : '"_self"';
+                    $target = $data[open_in_new_window] ? '_blank' : '_self';
                 }
                 else {
-                    $target = $this->getConf('open_in_new_window') ? '"_blank"' : '"_self"';
+                    $target = $this->getConf('open_in_new_window') ? '_blank' : '_self';
                 }
                 unset($data['open_in_new_window']); // hide open_in_new_window for the url params
-                $renderer->doc .= '<a target='.$target.' href="'.exportlink($ID,'revealjs',count($data)?$data:null).'" title="'.$this->getLang('view').'">';
+                $renderer->doc .= '<a target="'.$target.'" href="'.exportlink($ID,'revealjs',count($data)?$data:null).'" title="'.$this->getLang('view').'">';
                 $renderer->doc .= '<img src="'.DOKU_BASE.'lib/plugins/revealjs/start_button.png" align="right" alt="'.$this->getLang('view').'"/>';
                 $renderer->doc .= '</a>';
             }


### PR DESCRIPTION
Hi,

regarding issue #8 - this is a general solution for all current and possible future options. 

Please have a look and let me know, if I should change something or if you don't like this at all.

Best regards
Ottmar


# Changes overview


## syntax/theme.php

### Parse options as query string

Allow the old syntax for only the theme name or the the new syntax for more options as a query string like 

```
~~REVEAL theme=sky&transition=convex&controls=1~~
```

### Put all options except `open_in_new_window` to the export URL


## renderer.php

### Merge URL params into plugin conf

Changing parameters direct in the URL is only working, when the page is not cached (`~~NOCACHE~~`).

The good thing with `~~NOCACHE~~` is, that you are able to change the layout on the fly by only changing the URL. If you encounter any problems during a presentation e.g. bad contrast, then you are able to change this without editing the wiki page.


## example_presentation.dokuwiki

### Example parameters, new List page and cleanup


## README.md

### Add description for the new functionality