### PR TITLE
New options slide level and push nested slide headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,29 @@ This started as a fork of Andreas Gohr's S5 plugin https://www.dokuwiki.org/plug
 
 It uses Reveal.js https://github.com/hakimel/reveal.js/.
 
+
+
 Install
 -------
 
 Paste the address git config http://github.com/neuralyzer/dokuwiki-plugin-revealjs/zipball/master in the manual installation field or use Dokuwiki's extension manager.
 
 
+
 Usage
 -----
 
-
-Every new H1 or H2 section, that is  6 equal signs or 5 equal signs open a new slide horizontally.
+Every new H1 or H2 section, that is 6 equal signs or 5 equal signs open per default a new slide horizontally.
 New H3 sections (4 equal signs) are appended vertically if they follow after an H2 section.
-
-**Caution**: Only H2 sections open the vertical axis. If an H3 section follows after an H1 section it is appended horizontally.
 
 Add ``~~REVEAL~~`` to a page to insert a button for presentation start.
 
 Check also the source code of the [example presentation](example_presentation.dokuwiki)
 
+
+
 Include plugin compatibility
 ----------------------------
-
-
 
 Edit in the file dokuwiki/lib/plugin/include/syntax/wrap.php in the function render the line
 
@@ -66,8 +66,8 @@ Configuration is done in DokuWiki's configuration manager.
 ![Reveal.js configuration](revealjs_configuration.png)
 
 
-### Available themes
 
+### Available themes
 
 Available themes are the Reveal.js themes. Possible values:
 
@@ -97,7 +97,7 @@ Show the reveal.js controls. Two values
 The default is false.
 
 
-### Progres bar
+### Progress bar
 
 Show the reveal.js progress bar. Two values
 
@@ -121,7 +121,6 @@ The default is false
 
 The slide transition. Possible settings:
 
-
   * none
   * fade
   * slide
@@ -139,6 +138,23 @@ Whether to build up all bullet point lists item by item by for every slide.
 The default is false.
 
 
+### Slide level
+
+Headers on this level or above starting a horizontal slide. Levels below starting a vertical (nested) slide. Possible settings:
+
+  * 1
+  * 2
+
+The default is 2.
+
+
+### Push headers
+
+Push headers below slide_level to the next higher one.
+
+The default is false.
+
+
 
 Supported dokuwiki syntax
 -------------------------
@@ -150,8 +166,10 @@ Apart of the ordinary things like headlines, tables, italic, bold etc. the follo
   * ``<WRAP clear></WRAP>`` for clearing of floats
 
 
+
 Extra syntax
 ------------
+
 
 ### Theme selection and button for presentation start
 
@@ -172,6 +190,7 @@ All other options are also overwritable in a wiki page by using the URL query pa
 ~~REVEAL theme=sky&transition=convex&controls=1&show_progress_bar=1&build_all_lists=0&open_in_new_window=1~~
 ```
 Please note that boolean values must be numeric (1 or 0). If you want to be able to change the options directly in the URL after the presentation has started, then you have to disable DokuWiki's caching by putting `~~NOCACHE~~` at the top of the page.
+
 
 ### Slide background
 
@@ -232,6 +251,8 @@ slide without footer
 slide without footer and with background
 
 ```
+
+
 
 PDF export
 ----------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-dokuwiki-plugin-revealjs
-========================
+DokuWiki plugin Reveal.js
+=========================
 
-Reval.js plugin for dokuwiki
+Reval.js plugin for DokuWiki
 
 This started as a fork of Andreas Gohr's S5 plugin https://www.dokuwiki.org/plugin:s5.
 
@@ -114,7 +114,7 @@ Whether to build up all lists point by point. Two values
   * false
   * true
 
-The default is false
+The default is false.
 
 
 ### Transition
@@ -131,13 +131,6 @@ The slide transition. Possible settings:
 The default is fade.
 
 
-### Build all lists
-
-Whether to build up all bullet point lists item by item by for every slide.
-
-The default is false.
-
-
 ### Slide level
 
 Headers on this level or above starting a horizontal slide. Levels below starting a vertical (nested) slide. Possible settings:
@@ -150,7 +143,10 @@ The default is 2.
 
 ### Push headers
 
-Push headers below slide_level to the next higher one.
+Push headers below slide_level to the next higher one. Boolean:
+
+* false
+* true
 
 The default is false.
 
@@ -232,7 +228,7 @@ produces one slide with background and a second slide without background.
 
 ### Footers
 
-Sometimes you might want to have a footer for all the pages. This footer might contain your company's logo or similar things. Footers are most conveniently added using in addition the dokuwiki plugin "wrap". To get a footer on each page put at the very beginning of your document, i.e. before the first heading but possibly after a ``~~NOCACHE`` or ``~~REVEAL~~`` the following block
+Sometimes you might want to have a footer for all the pages. This footer might contain your company's logo or similar things. Footers are most conveniently added using in addition the dokuwiki plugin "wrap". To get a footer on each page put at the very beginning of your document, i.e. before the first heading but possibly after a ``~~NOCACHE~~`` or ``~~REVEAL~~`` the following block
 ```
 <wrap footer>Footer content here.</wrap>
 ```

--- a/conf/default.php
+++ b/conf/default.php
@@ -5,4 +5,5 @@ $conf['build_all_lists'] = 0;
 $conf['transition'] = 'fade';
 $conf['show_progress_bar'] = 0;
 $conf['open_in_new_window'] = 1;
-
+$conf['slide_level'] = 2;
+$conf['push_headers'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -6,3 +6,5 @@ $meta['build_all_lists'] = array('onoff');
 $meta['transition'] = array('multichoice','_choices' => array('none', 'fade', 'slide', 'convex', 'concave', 'zoom'));
 $meta['show_progress_bar'] = array('onoff');
 $meta['open_in_new_window'] = array('onoff');
+$meta['slide_level'] = array('multichoice','_choices' => array(1, 2));
+$meta['push_headers'] = array('onoff');

--- a/example_presentation.dokuwiki
+++ b/example_presentation.dokuwiki
@@ -1,10 +1,15 @@
 ~~NOCACHE~~
-~~REVEAL theme=sky&transition=convex&controls=1&show_progress_bar=1&build_all_lists=1&open_in_new_window=1~~
+~~REVEAL slide_level=2&push_headers=0&theme=sky&transition=convex&controls=1&show_progress_bar=1&build_all_lists=1&push_headers=1&open_in_new_window=1~~
 
 
 ====== Revealjs Test ======
 
 This is a test suite for the reval.js plugin.
+
+
+==== Header level test ====
+
+Test, if an H3 section following an H1 section is appended horizontally or vertically.
 
 
 ===== Caching =====

--- a/example_presentation.dokuwiki
+++ b/example_presentation.dokuwiki
@@ -1,4 +1,5 @@
 ~~NOCACHE~~
+~~REVEAL theme=sky&transition=convex&controls=1&show_progress_bar=1&build_all_lists=1&slide_level=2&push_headers=0&open_in_new_window=1~~
 
 
 ====== Revealjs Test ======

--- a/example_presentation.dokuwiki
+++ b/example_presentation.dokuwiki
@@ -1,5 +1,4 @@
 ~~NOCACHE~~
-~~REVEAL slide_level=2&push_headers=0&theme=sky&transition=convex&controls=1&show_progress_bar=1&build_all_lists=1&push_headers=1&open_in_new_window=1~~
 
 
 ====== Revealjs Test ======

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -4,12 +4,14 @@
  *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Emmanuel Klinger <emmanuel.klinger@gmail.com>
- */ 
+ */
 
- 
+
 $lang['theme'] = "Theme of the presentation";
 $lang['controls'] = "Show slide controls";
 $lang['build_all_lists'] = "Build all lists incrementally";
 $lang['transition'] = "Slide transition";
 $lang['show_progress_bar'] = "Show the progress bar";
 $lang['open_in_new_window'] = "Open a presentation in a new window or tab";
+$lang['slide_level'] = "Headers on this level or above starting a horizontal slide. Levels below starting a vertical (nested) slide";
+$lang['push_headers'] = "Push headers below slide_level to the next higher one";

--- a/renderer.php
+++ b/renderer.php
@@ -55,11 +55,11 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
             if (!array_key_exists('plugin', $conf)) {
                 $conf['plugin'] = array('revealjs' => $_GET);
             }
-            elseif (!array_key_exists('revealjs', $conf[plugin])) {
-                $conf[plugin]['revealjs'] = $_GET;
+            elseif (!array_key_exists('revealjs', $conf['plugin'])) {
+                $conf['plugin']['revealjs'] = $_GET;
             }
             else {
-                $conf[plugin][revealjs] = array_merge($conf[plugin][revealjs], $_GET);
+                $conf['plugin']['revealjs'] = array_merge($conf['plugin']['revealjs'], $_GET);
             }
         }
 
@@ -381,7 +381,6 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
     * This is called "fragment" in reveal.js
     */
     function listitem_open($level, $node=false) {
-        dbg($conf);
         if($this->getConf('build_all_lists')) {
           $this->doc .= '<li class="fragment">';
        } else {

--- a/renderer.php
+++ b/renderer.php
@@ -199,24 +199,26 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
      * A new vertical slide for each H3 header
      */
     function header($text, $level, $pos) {
-        if($level <= 3){
+        $slide_level = $this->getConf('slide_level');
+        if($level <= $slide_level + 1){
             if($this->slide_open){
                 $this->doc .= '</section>'.DOKU_LF; //close previous slide
-                if ( ($this->column_open) && ($level <= 2) ) { // close nested section
+                if ( ($this->column_open) && ($level <= $slide_level) ) { // close nested section
                       $this->doc .= '</section>'.DOKU_LF;
                       $this->column_open = false;
                 }
             }
-            if ( $level <= 2 ) {   //first slide of possibly following nested ones if level is 2
-                 $this->create_slide_section(false);
+            if ( $level <= $slide_level ) { //first slide of possibly following nested ones if level is slide_level
+                 $this->create_slide_section(false); # always without background to not to have a background for a whole subsection
                  $this->column_open = true;
             }
-            $this->create_slide_section(true); # always without background to not to have a background for a whole subsection
+            $this->create_slide_section(true);
             $this->slide_open = true;
         }
-        $this->doc .= '<h'.$level.'>';
+        $level_calculated = ($level > $slide_level && $this->getConf('push_headers') ? $level - 1 : $level);
+        $this->doc .= '<h'. $level_calculated .'>';
         $this->doc .= $this->_xmlEntities($text);
-        $this->doc .= '</h'.$level.'>'.DOKU_LF;
+        $this->doc .= '</h'. $level_calculated .'>'.DOKU_LF;
     }
 
     /**
@@ -389,7 +391,7 @@ class renderer_plugin_revealjs extends Doku_Renderer_xhtml {
 
 
     /**
-     * Don't use Geshi. Overwrite ths Geshi function.
+     * Don't use Geshi. Overwrite the Geshi function.
      * @author Emmanuel Klinger
      * @author Andreas Gohr <andi@splitbrain.org>
      * @param string $type     code|file


### PR DESCRIPTION
Hi,

after your last comment on #13 I decided to leave the feature push_headers in the pull request. Feel free to delete the functionality - it is only one line in the configuration files and 4 lines in the header function in the renderer.php and of course the README.md and one parameter in the example presentation button definition. I have currently no better solution for this and as you commented may be all other ideas for this problem are more complex to implement.

Again sorry for the forgotten quotes and the debug call. Four eyes see more than two :-)

Best regards
Ottmar
# Changes overview

To make the organization of slide shows more flexible we introduce two new parameters: slide_level and push_headers. For a description see settings.php (next section). An example: I often organize my slideshows with H1 horizontal slides for the main points and then H2 vertical slides for the details. With the existing implementation I am not able to have H2 vertical (nested) slides, because only H3 headers goes vertical. And H3 headers are simply too small - for the presentation and also for the wiki page - they break the logic, that after a H1 header we normally use a H2 header for the subpoints. By setting the slide level to 1 this is possible. Since all parameters are now overwritable per wiki page, we can adapt this for each presentation. 

If we use slide_level 2 to have H1 and H2 header slides horizontally, then we can push all headers on vertical slide by one with the option push_headers. This can fix our problem with too small slide headers on vertical slides.

At the end we have more flexible ways to organize our slides. In the default settings nothing changes for existing slides - we are backward compatible.
## lang/en/settings.php

``` php
$lang['slide_level'] = "Headers on this level or above starting a horizontal slide. Levels below starting a vertical (nested) slide";
$lang['push_headers'] = "Push headers below slide_level to the next higher one";
```
## conf/metadata.php

``` php
$meta['slide_level'] = array('multichoice','_choices' => array(1, 2));
$meta['push_headers'] = array('onoff');
```
## conf/default.php

``` php
$conf['slide_level'] = 2;
$conf['push_headers'] = 0;
```
## renderer.php
- Function header: implement the two new options slide_level and push_headers

``` php
    function header($text, $level, $pos) {
        $slide_level = $this->getConf('slide_level');
        if($level <= $slide_level + 1){
            if($this->slide_open){
                $this->doc .= '</section>'.DOKU_LF; //close previous slide
                if ( ($this->column_open) && ($level <= $slide_level) ) { // close nested section
                      $this->doc .= '</section>'.DOKU_LF;
                      $this->column_open = false;
                }
            }
            if ( $level <= $slide_level ) { //first slide of possibly following nested ones if level is slide_level
                 $this->create_slide_section(false); # always without background to not to have a background for a whole subsection
                 $this->column_open = true;
            }
            $this->create_slide_section(true);
            $this->slide_open = true;
        }
        $level_calculated = ($level > $slide_level && $this->getConf('push_headers') ? $level - 1 : $level);
        $this->doc .= '<h'. $level_calculated .'>';
        $this->doc .= $this->_xmlEntities($text);
        $this->doc .= '</h'. $level_calculated .'>'.DOKU_LF;
    }
```
## example_presentation.dokuwiki
- Add the new example options to the start slideshow button
- New testcase for "H3 section following an H1 section"
- Cosmetic changes
## README.md
- Add description for the new functionality
- Cosmetic changes
- Delete the following warning, because it is in the current implementation not true - An H3 section following an H1 section is currently appended vertically:

```
**Caution**: Only H2 sections open the vertical axis. If an H3 section follows after an H1 section it is appended horizontally.
```
